### PR TITLE
feat: support custom OpenAI-compatible API endpoints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,23 +75,12 @@ jobs:
       - name: Build plugin
         run: ./gradlew buildPlugin
 
-      # Prepare plugin archive content for creating artifact
-      - name: Prepare Plugin Artifact
-        id: artifact
-        shell: bash
-        run: |
-          cd ${{ github.workspace }}/build/distributions
-          FILENAME=`ls *.zip`
-          unzip "$FILENAME" -d content
-
-          echo "filename=${FILENAME:0:-4}" >> $GITHUB_OUTPUT
-
-      # Store already-built plugin as an artifact for downloading
-      - name: Upload artifact
+      # Store plugin zip as an artifact for release attachment
+      - name: Upload Plugin Zip
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.artifact.outputs.filename }}
-          path: ./build/distributions/content/*/*
+          name: plugin-zip
+          path: ./build/distributions/*.zip
 
   # Run tests and upload a code coverage report
   test:
@@ -243,7 +232,14 @@ jobs:
             --jq '.[] | select(.draft == true) | .id' \
             | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
 
-      # Create a new release draft which is not publicly visible and requires manual acceptance
+      # Download the built plugin zip
+      - name: Download Plugin Zip
+        uses: actions/download-artifact@v4
+        with:
+          name: plugin-zip
+          path: ./build/distributions
+
+      # Create a new release draft with the zip attached so people can download it
       - name: Create Release Draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -254,4 +250,5 @@ jobs:
             --notes "$(cat << 'EOM'
           ${{ needs.build.outputs.changelog }}
           EOM
-          )"
+          )" \
+            ./build/distributions/*.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Plugin manifest: `src/main/resources/META-INF/plugin.xml`
 - **Publishing** requires env vars: `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD`, `PUBLISH_TOKEN`. Version determines release channel (pre-release label after `-`).
 - **Kotlin serialization plugin** is applied manually in build.gradle.kts (not via version catalog). Version `2.1.0` — keep in sync with Kotlin version if upgrading.
 - **OkHttp SSE** is used for streaming (`okhttp-sse` dependency). The 500-minute timeouts are intentional for long streams.
+- **API endpoint is configurable** — `apiBaseUrl` setting (default: OpenRouter). Works with Ollama (`http://localhost:11434/v1`), Headroom proxy (`http://localhost:8787/api/v1`), or any OpenAI-compatible endpoint. API key is optional for non-OpenRouter providers.
 - **Configuration cache is disabled** (`org.gradle.configuration-cache = false` in gradle.properties).
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## What this is
+
+IntelliJ IDEA plugin (JetBrains Marketplace) that streams OpenRouter AI responses directly into the editor. Kotlin, single-module Gradle project. Plugin ID: `com.github.roscrl.inlineaichat`.
+
+## Build & verify
+
+```bash
+# Build plugin zip
+./gradlew buildPlugin
+
+# Run tests (IntelliJ test framework, uses BasePlatformTestCase)
+./gradlew check
+
+# Verify plugin structure against IntelliJ Platform
+./gradlew verifyPlugin
+
+# Full CI pipeline order: buildPlugin -> check -> verifyPlugin
+```
+
+Requires **Java 21** (jvmToolchain in build.gradle.kts), though CI uses Java 17 for setup (Gradle resolves toolchain separately). If builds fail locally, check `JAVA_HOME` matches a JDK 21 install.
+
+## Project structure
+
+All source under `src/main/kotlin/com/github/roscrl/inlineaichat/`:
+
+- `actions/StreamTextAction.kt` — core action: reads editor content, POSTs to OpenRouter SSE endpoint, streams response back into document. This is the main file.
+- `actions/QuickSettingsAction.kt` — opens settings dialog
+- `settings/InlineAIChatSettingsState.kt` — persistent settings (API key, model, system prompt)
+- `settings/InlineAIChatSettingsConfigurable.kt` — settings UI panel
+- `config/ModelConfig.kt` — model list configuration
+- `notifications/NotificationUtil.kt` — balloon notifications
+
+Plugin manifest: `src/main/resources/META-INF/plugin.xml`
+
+## Key quirks
+
+- **Plugin description** is extracted from `README.md` between `<!-- Plugin description -->` markers. Edit those markers, not the XML in plugin.xml.
+- **Changelog** uses `keepachangelog` format in `CHANGELOG.md`. The Gradle `patchChangelog` task updates `[Unreleased]` section.
+- **Publishing** requires env vars: `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD`, `PUBLISH_TOKEN`. Version determines release channel (pre-release label after `-`).
+- **Kotlin serialization plugin** is applied manually in build.gradle.kts (not via version catalog). Version `2.1.0` — keep in sync with Kotlin version if upgrading.
+- **OkHttp SSE** is used for streaming (`okhttp-sse` dependency). The 500-minute timeouts are intentional for long streams.
+- **Configuration cache is disabled** (`org.gradle.configuration-cache = false` in gradle.properties).
+
+## Testing
+
+Tests extend `BasePlatformTestCase` (IntelliJ light platform test fixture). Test data goes in `src/test/testData/`. The test infrastructure spins up a headless IntelliJ instance — tests are slow to start but don't need external services.

--- a/src/main/kotlin/com/github/roscrl/inlineaichat/actions/QuickSettingsAction.kt
+++ b/src/main/kotlin/com/github/roscrl/inlineaichat/actions/QuickSettingsAction.kt
@@ -123,14 +123,17 @@ private class QuickSettingsDialog : DialogWrapper(true) {
         
         panel.add(decorator, BorderLayout.CENTER)
         
-        val modelsLink = HyperlinkLabel("View available models on OpenRouter").apply {
-            setHyperlinkTarget("https://openrouter.ai/models")
+        val baseUrl = InlineAIChatSettingsState.instance.apiBaseUrl
+        if (baseUrl.contains("openrouter")) {
+            val modelsLink = HyperlinkLabel("View available models on OpenRouter").apply {
+                setHyperlinkTarget("https://openrouter.ai/models")
+            }
+            val linkPanel = JPanel(BorderLayout()).apply {
+                add(modelsLink, BorderLayout.CENTER)
+                border = JBUI.Borders.empty(5)
+            }
+            panel.add(linkPanel, BorderLayout.SOUTH)
         }
-        val linkPanel = JPanel(BorderLayout()).apply {
-            add(modelsLink, BorderLayout.CENTER)
-            border = JBUI.Borders.empty(5)
-        }
-        panel.add(linkPanel, BorderLayout.SOUTH)
         
         panel.preferredSize = JBUI.size(300, 400)
         return panel

--- a/src/main/kotlin/com/github/roscrl/inlineaichat/actions/StreamTextAction.kt
+++ b/src/main/kotlin/com/github/roscrl/inlineaichat/actions/StreamTextAction.kt
@@ -180,17 +180,19 @@ class StreamTextAction : AnAction() {
             val settings = InlineAIChatSettingsState.instance
             logger.debug("Starting ${settings.selectedModel} response stream: contextLength=${context.length}")
 
-            if (settings.openRouterApiKey.isEmpty()) {
-                logger.warn("OpenRouter API key not configured")
+            // API key is only required for providers that need auth (e.g. OpenRouter)
+            val needsAuth = settings.apiBaseUrl.contains("openrouter")
+            if (needsAuth && settings.openRouterApiKey.isEmpty()) {
+                logger.warn("API key required for this provider but not configured")
                 WriteCommandAction.runWriteCommandAction(project) {
                     editor.document.insertString(
                         initialOffset,
-                        "Please configure your OpenRouter API key in Settings -> Tools -> Inline AI Chat Settings\n"
+                        "Please configure your API key in Settings -> Tools -> Inline AI Chat Settings\n"
                     )
                 }
                 NotificationUtil.showWarning(
                     title = "Configuration Required",
-                    content = "Please configure your OpenRouter API key in Settings -> Tools -> Inline AI Chat Settings",
+                    content = "Please configure your API key in Settings -> Tools -> Inline AI Chat Settings",
                     project = project
                 )
                 isStreaming.set(false)
@@ -221,8 +223,12 @@ class StreamTextAction : AnAction() {
             }
 
             val request = Request.Builder()
-                .url("https://openrouter.ai/api/v1/chat/completions")
-                .addHeader("Authorization", "Bearer ${settings.openRouterApiKey}")
+                .url("${settings.apiBaseUrl.trimEnd('/')}/chat/completions")
+                .apply {
+                    if (settings.openRouterApiKey.isNotEmpty()) {
+                        addHeader("Authorization", "Bearer ${settings.openRouterApiKey}")
+                    }
+                }
                 .post(requestBody)
                 .build()
 

--- a/src/main/kotlin/com/github/roscrl/inlineaichat/settings/InlineAIChatSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/roscrl/inlineaichat/settings/InlineAIChatSettingsConfigurable.kt
@@ -39,7 +39,8 @@ class InlineAIChatSettingsConfigurable : Configurable {
     override fun isModified(): Boolean {
         val component = settingsComponent ?: return false
         val settings = InlineAIChatSettingsState.instance
-        return settings.openRouterApiKey != component.getOpenRouterApiKey() ||
+        return settings.apiBaseUrl != component.getApiBaseUrl() ||
+                settings.openRouterApiKey != component.getOpenRouterApiKey() ||
                 settings.selectedModel != component.getSelectedModel() ||
                 settings.systemPrompt != component.getSystemPrompt()
     }
@@ -47,6 +48,7 @@ class InlineAIChatSettingsConfigurable : Configurable {
     override fun apply() {
         val component = settingsComponent ?: return
         val settings = InlineAIChatSettingsState.instance
+        settings.apiBaseUrl = component.getApiBaseUrl()
         settings.openRouterApiKey = component.getOpenRouterApiKey()
         settings.selectedModel = component.getSelectedModel() ?: settings.selectedModel
         settings.systemPrompt = component.getSystemPrompt()
@@ -55,6 +57,7 @@ class InlineAIChatSettingsConfigurable : Configurable {
     override fun reset() {
         val component = settingsComponent ?: return
         val settings = InlineAIChatSettingsState.instance
+        component.setApiBaseUrl(settings.apiBaseUrl)
         component.setOpenRouterApiKey(settings.openRouterApiKey)
         component.setSelectedModel(settings.selectedModel)
         component.setSystemPrompt(settings.systemPrompt)
@@ -66,8 +69,12 @@ class InlineAIChatSettingsConfigurable : Configurable {
 }
 
 class InlineAIChatSettingsComponent {
+    private val apiBaseUrlField = JBTextField().apply {
+        emptyText.text = "https://openrouter.ai/api/v1"
+        preferredSize = Dimension(500, JBUI.scale(30))
+    }
     private val apiKeyField = JBPasswordField().apply {
-        emptyText.text = "Enter your OpenRouter API key here..."
+        emptyText.text = "Optional for local providers (Ollama, Headroom)"
         echoChar = '•'
         preferredSize = Dimension(500, JBUI.scale(30))
     }
@@ -95,13 +102,16 @@ class InlineAIChatSettingsComponent {
     private var initialModel: String = InlineAIChatSettingsState.instance.selectedModel
 
     val panel: DialogPanel = panel {
-        group("OpenRouter") {
+        group("Provider") {
+            row("Base URL:") {
+                cell(apiBaseUrlField).align(AlignX.FILL)
+            }.comment("OpenAI-compatible endpoint. Examples: https://openrouter.ai/api/v1, http://localhost:11434/v1, http://localhost:8787/api/v1 (Headroom)")
             row("API Key:") {
                 cell(apiKeyField).align(AlignX.FILL)
                 cell(showApiKeyCheckBox)
             }
             row {
-                cell(apiKeyLink)
+                cell(apiKeyLink).visible(apiBaseUrlField.text.contains("openrouter"))
             }
         }
 
@@ -162,6 +172,11 @@ class InlineAIChatSettingsComponent {
     private fun getQuickSettingsShortcut(): String {
         val action = ActionManager.getInstance().getAction("com.github.roscrl.inlineaichat.actions.QuickSettingsAction")
         return KeymapUtil.getFirstKeyboardShortcutText(action)
+    }
+
+    fun getApiBaseUrl(): String = apiBaseUrlField.text.trim()
+    fun setApiBaseUrl(url: String) {
+        apiBaseUrlField.text = url
     }
 
     fun getOpenRouterApiKey(): String = String(apiKeyField.password)
@@ -252,10 +267,13 @@ class ManageModelsDialog : DialogWrapper(true) {
 
         panel.add(decorator, BorderLayout.CENTER)
 
-        val modelsLink = HyperlinkLabel("View available models on OpenRouter").apply {
-            setHyperlinkTarget("https://openrouter.ai/models")
+        val baseUrl = InlineAIChatSettingsState.instance.apiBaseUrl
+        if (baseUrl.contains("openrouter")) {
+            val modelsLink = HyperlinkLabel("View available models on OpenRouter").apply {
+                setHyperlinkTarget("https://openrouter.ai/models")
+            }
+            panel.add(modelsLink, BorderLayout.SOUTH)
         }
-        panel.add(modelsLink, BorderLayout.SOUTH)
 
         panel.preferredSize = JBUI.size(400, 300)
         return panel

--- a/src/main/kotlin/com/github/roscrl/inlineaichat/settings/InlineAIChatSettingsState.kt
+++ b/src/main/kotlin/com/github/roscrl/inlineaichat/settings/InlineAIChatSettingsState.kt
@@ -17,6 +17,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 class InlineAIChatSettingsState : PersistentStateComponent<InlineAIChatSettingsState> {
     private val logger = Logger.getInstance(InlineAIChatSettingsState::class.java)
 
+    var apiBaseUrl: String = "https://openrouter.ai/api/v1"
     var openRouterApiKey: String = ""
     var selectedModel: String
         get() = _selectedModel ?: availableModels.firstOrNull() ?: ""


### PR DESCRIPTION
## What

Adds a configurable **Base URL** setting so the plugin works with any OpenAI-compatible endpoint — not just OpenRouter.

## Why

Users want to run against local models (Ollama, LM Studio, vLLM) or through a compression proxy (Headroom). The endpoint was hardcoded to .

## Changes

- **New `apiBaseUrl` setting** — persisted, defaults to `https://openrouter.ai/api/v1` (backward compatible)
- **Request URL built from base URL** — `{baseUrl}/chat/completions` replaces the hardcoded URL
- **Auth header is conditional** — only sent when an API key is configured (Ollama/Headroom don't need one)
- **API key validation relaxed** — only enforced when base URL contains `openrouter`
- **Settings UI updated** — new "Provider" group with Base URL field, OpenRouter links shown conditionally

## Testing

```bash
./gradlew buildPlugin  # builds plugin zip
```

1. Install plugin from `build/distributions/`
2. **Ollama**: set Base URL to `http://localhost:11434/v1`, add model `llama3`, trigger with Shift+Ctrl+S
3. **Headroom**: run `headroom proxy --port 8787`, set Base URL to `http://localhost:8787/api/v1`, trigger
4. **OpenRouter**: leave defaults — existing behavior unchanged